### PR TITLE
Fix issue14 update ref

### DIFF
--- a/xoa_converter/converters/common.py
+++ b/xoa_converter/converters/common.py
@@ -13,13 +13,15 @@ from pydantic.fields import Field
 from operator import attrgetter
 
 if TYPE_CHECKING:
-    from xoa_converter.converters.rfc2544.model import LegacyStreamProfileHandler as LegacyStreamProfile2544
+    from xoa_converter.converters.rfc2544.model import (
+        LegacyStreamProfileHandler as LegacyStreamProfile2544,
+    )
     from types import ModuleType
 
 
-
 CURRENT_FILE_PARENT_PATH = Path(__file__).parent.resolve()
-SEGMENT_REFS_FOLDER = CURRENT_FILE_PARENT_PATH / 'segment_refs'
+SEGMENT_REFS_FOLDER = CURRENT_FILE_PARENT_PATH / "segment_refs"
+
 
 class PortIdentity(BaseModel):
     tester_id: str
@@ -39,24 +41,21 @@ class TestParameters(BaseModel):
 
     @property
     def get_testers_ids(self) -> Set[str]:
-        return set(map(
-            attrgetter("tester_id"),
-            self.port_identities.values()
-        ))
+        return set(map(attrgetter("tester_id"), self.port_identities.values()))
 
 
 class LegacySegmentField(BaseModel):
-    name: str = Field(alias='Name')
-    bit_length: int = Field(alias='BitLength')
-    bit_position: Optional[int] = None # position of current segment
+    name: str = Field(alias="Name")
+    bit_length: int = Field(alias="BitLength")
+    bit_position: Optional[int] = None  # position of current segment
 
 
 class SegmentRef(BaseModel):
-    name: str = Field(alias='Name')
-    description: str = Field(alias='Description')
-    segment_type: str = Field(alias='SegmentType')
-    checksum_offset: Optional[int] = Field(alias='ChecksumOffset')
-    protocol_fields: List[LegacySegmentField] = Field(alias='ProtocolFields')
+    name: str = Field(alias="Name")
+    description: str = Field(alias="Description")
+    segment_type: str = Field(alias="SegmentType")
+    checksum_offset: Optional[int] = Field(alias="ChecksumOffset")
+    protocol_fields: List[LegacySegmentField] = Field(alias="ProtocolFields")
 
     def calc_field_position(self) -> None:
         bit_position_count = 0
@@ -70,11 +69,15 @@ class SegmentRef(BaseModel):
 
 
 def load_segment_refs_json(segment_type_value: str) -> SegmentRef:
-    segment_ref = SegmentRef.parse_file(SEGMENT_REFS_FOLDER / f'{segment_type_value}.json')
+    segment_ref = SegmentRef.parse_file(
+        SEGMENT_REFS_FOLDER / f"{segment_type_value}.json"
+    )
     return segment_ref
 
 
-def convert_protocol_segments(stream_profile_handler: "LegacyStreamProfile2544", target_module: "ModuleType") -> Dict:
+def convert_protocol_segments(
+    stream_profile_handler: "LegacyStreamProfile2544",
+) -> Dict:
     protocol_segments_profile = {}
 
     for profile in stream_profile_handler.entity_list:
@@ -85,52 +88,52 @@ def convert_protocol_segments(stream_profile_handler: "LegacyStreamProfile2544",
             field_value_ranges = {}
             for hm in profile.stream_config.hw_modifiers:
                 if hm.segment_id == hs.item_id:
-                    hw_modifiers[hm.field_name] = target_module.HWModifier.construct(
+                    hw_modifiers[hm.field_name] = dict(
                         start_value=hm.start_value,
                         stop_value=hm.stop_value,
                         step_value=hm.step_value,
                         repeat=hm.repeat_count,
-                        action=target_module.ModifierActionOption[
-                            hm.action.name.lower()
-                        ],
+                        action=hm.action.name.lower(),
                         mask=f"{base64.b64decode(hm.mask).hex()}0000",
                         offset=hm.offset,
                     )
             for hvr in profile.stream_config.field_value_ranges:
                 if hvr.segment_id == hs.item_id:
-                    field_value_ranges[hvr.field_name] = target_module.ValueRange.construct(
+                    field_value_ranges[hvr.field_name] = dict(
                         field_name=hvr.field_name,
                         start_value=hvr.start_value,
                         stop_value=hvr.stop_value,
                         step_value=hvr.step_value,
-                        action=target_module.ModifierActionOption[
-                            hvr.action.name.lower()
-                        ],
+                        action=hvr.action.name.lower(),
                         restart_for_each_port=hvr.reset_for_each_port,
                     )
 
             segment_ref = load_segment_refs_json(hs.segment_type.value)
-            segment_value = bin(int('1'+base64.b64decode(hs.segment_value).hex(), 16))[3:]
+            segment_value = bin(
+                int("1" + base64.b64decode(hs.segment_value).hex(), 16)
+            )[3:]
             converted_fields = []
 
             for field in segment_ref.protocol_fields:
                 converted_fields.append(
-                    target_module.SegmentField.construct(
+                    dict(
                         name=field.name,
-                        value=segment_value[:field.bit_length],
+                        value=segment_value[: field.bit_length],
                         bit_length=field.bit_length,
                         hw_modifier=hw_modifiers.get(field.name),
                         value_range=field_value_ranges.get(field.name),
                     )
                 )
-                segment_value = segment_value[field.bit_length:]
+                segment_value = segment_value[field.bit_length :]
 
-            segment = target_module.ProtocolSegment.construct(
-                segment_type=target_module.SegmentType[hs.segment_type.name.lower()],
+            segment = dict(
+                segment_type=hs.segment_type.name.lower(),
                 fields=converted_fields,
                 checksum_offset=segment_ref.checksum_offset,
             )
             header_segments.append(segment)
 
-        protocol_segments_profile[profile.item_id] = target_module.ProtocolSegmentProfileConfig.construct(header_segments=header_segments)
+        protocol_segments_profile[profile.item_id] = dict(
+            header_segments=header_segments
+        )
     return protocol_segments_profile

--- a/xoa_converter/converters/common.py
+++ b/xoa_converter/converters/common.py
@@ -7,7 +7,6 @@ from typing import (
     Optional,
     Set,
     TYPE_CHECKING,
-    Union,
 )
 from pydantic import BaseModel
 from pydantic.fields import Field
@@ -35,8 +34,8 @@ class PortIdentity(BaseModel):
 
 class TestParameters(BaseModel):
     username: str
-    port_identities: Dict[str, PortIdentity]
-    config: BaseModel
+    port_identities: Dict[str, Dict]
+    config: Dict
 
     @property
     def get_testers_ids(self) -> Set[str]:

--- a/xoa_converter/converters/rfc2544/adapter.py
+++ b/xoa_converter/converters/rfc2544/adapter.py
@@ -1,16 +1,7 @@
 import hashlib
-import types
-from decimal import Decimal
-from typing import Dict, Union, TYPE_CHECKING
-from .model import (
-    LegacyModel2544 as old_model,
-    LegacyFrameSizesOptions,
-)
-from ..common import (
-    TestParameters,
-    PortIdentity,
-    convert_protocol_segments,
-)
+from typing import List, Dict, Union, TYPE_CHECKING
+from .model import LegacyModel2544 as old_model
+from ..common import convert_protocol_segments
 
 if TYPE_CHECKING:
     from .model import (
@@ -22,27 +13,24 @@ if TYPE_CHECKING:
         LegacyPortEntity,
         LegacyThroughput,
     )
-from loguru import logger
 
 
 def convert_base_mac_address(mac_address: str) -> str:
     prefix = [hex(int(i)) for i in mac_address.split(",")]
-    return ":".join([p.replace("0x", "").zfill(2).upper() for p in prefix])
+    return ":".join([p.replace("0x", "").zfill(2).lower() for p in prefix])
 
 
 class Converter2544:
-    def __init__(self, source_config: str, target_module: types.ModuleType) -> None:
+    def __init__(self, source_config: str) -> None:
         self.id_map = {}
-        self.module = target_module
         self.data = old_model.parse_raw(source_config)
 
-
-    def __gen_frame_size(self):
+    def __gen_frame_size(self) -> Dict:
         packet_size = self.data.test_options.packet_sizes
         packet_size_type = packet_size.packet_size_type
         fz = packet_size.mixed_length_config.frame_sizes
-        return self.module.FrameSizeConfiguration.construct(
-            packet_size_type=self.module.PacketSizeType[packet_size_type.name.lower()],
+        return dict(
+            packet_size_type=packet_size_type.name.lower(),
             custom_packet_sizes=packet_size.custom_packet_sizes,
             fixed_packet_start_size=packet_size.sw_packet_start_size,
             fixed_packet_end_size=packet_size.sw_packet_end_size,
@@ -50,12 +38,12 @@ class Converter2544:
             varying_packet_min_size=packet_size.hw_packet_min_size,
             varying_packet_max_size=packet_size.hw_packet_max_size,
             mixed_sizes_weights=packet_size.mixed_sizes_weights,
-            mixed_length_config=LegacyFrameSizesOptions(**fz),
+            mixed_length_config=fz,
         )
 
-    def __gen_multi_stream_config(self):
+    def __gen_multi_stream_config(self) -> Dict:
         flow_option = self.data.test_options.flow_creation_options
-        return self.module.MultiStreamConfig.construct(
+        return dict(
             enable_multi_stream=flow_option.enable_multi_stream,
             per_port_stream_count=flow_option.per_port_stream_count,
             multi_stream_address_offset=flow_option.multi_stream_address_offset,
@@ -65,44 +53,36 @@ class Converter2544:
             ),
         )
 
-    def __gen_port_sync_config(self):
+    def __gen_port_sync_config(self) -> Dict:
         test_options = self.data.test_options
-        my_class = getattr(self.module, "TogglePortSyncConfig")
-        return my_class.construct(
+
+        return dict(
             delay_after_sync_on_second=test_options.sync_on_duration,
             toggle_port_sync=test_options.toggle_sync_state,
             sync_off_duration_second=test_options.sync_off_duration,
         )
 
-    def __gen_test_config(self):
+    def __gen_test_config(self) -> Dict:
         test_options = self.data.test_options
         flow_option = test_options.flow_creation_options
         payload = test_options.payload_definition
         learning_options = test_options.learning_options
-        topology = self.data.test_options.topology_config.topology
-        direction = self.module.TrafficDirection[
-            self.data.test_options.topology_config.direction.name.lower()
-        ]
+        topology = self.data.test_options.topology_config.topology.lower()
+        direction = self.data.test_options.topology_config.direction.name.lower()
         outer_loop_mode = test_options.outer_loop_mode
         tid_allocation_scope = self.data.tid_allocation_scope
         flow_creation_type = flow_option.flow_creation_type
         port_sync_config = self.__gen_port_sync_config()
         frame_size = self.__gen_frame_size()
-        return self.module.TestConfiguration.construct(
-            flow_creation_type=self.module.FlowCreationType[
-                flow_creation_type.name.lower()
-            ],
-            tid_allocation_scope=self.module.TidAllocationScope[
-                tid_allocation_scope.name.lower()
-            ],
+        return dict(
+            flow_creation_type=flow_creation_type.name.lower(),
+            tid_allocation_scope=tid_allocation_scope.name.lower(),
             mac_base_address=convert_base_mac_address(flow_option.mac_base_address),
             enable_speed_reduction_sweep=test_options.enable_speed_reduct_sweep,
             use_port_sync_start=test_options.use_port_sync_start,
             port_stagger_steps=test_options.port_stagger_steps,
-            outer_loop_mode=self.module.OuterLoopMode[outer_loop_mode.name.lower()],
-            mac_learning_mode=self.module.MACLearningMode[
-                learning_options.mac_learning_mode.name.lower()
-            ],
+            outer_loop_mode=outer_loop_mode.name.lower(),
+            mac_learning_mode=learning_options.mac_learning_mode.name.lower(),
             mac_learning_frame_count=learning_options.mac_learning_retries,
             toggle_port_sync_config=port_sync_config,
             learning_rate_pct=learning_options.learning_rate_percent,
@@ -120,16 +100,21 @@ class Converter2544:
             frame_sizes=frame_size,
             use_micro_tpld_on_demand=flow_option.use_micro_tpld_on_demand,
             payload_type=payload.payload_type,
-            payload_pattern="".join([hex(int(i)).replace("0x", "").zfill(2) for i in payload.payload_pattern.split(",")]),
+            payload_pattern="".join(
+                [
+                    hex(int(i)).replace("0x", "").zfill(2)
+                    for i in payload.payload_pattern.split(",")
+                ]
+            ),
             multi_stream_config=self.__gen_multi_stream_config(),
         )
 
     def __gen_rate_sweep_option(
         self,
         rate_sweep_options: "LegacyRateSweepOptions",
-        burst_resolution: Decimal = Decimal("0"),
-    ):
-        return self.module.RateSweepOptions.construct(
+        burst_resolution: float = 0.0,
+    ) -> Dict:
+        return dict(
             start_value_pct=rate_sweep_options.start_value,
             end_value_pct=rate_sweep_options.end_value,
             step_value_pct=rate_sweep_options.step_value,
@@ -141,46 +126,37 @@ class Converter2544:
         test_type_conf: Union[
             "LegacyThroughput", "LegacyLatency", "LegacyLoss", "LegacyBack2Back"
         ],
-    ):
-        duration_type = self.module.DurationType[
-            test_type_conf.duration_type.name.lower()
-        ]
+    ) -> Dict:
+        duration_type = test_type_conf.duration_type.name.lower()
+
         is_time_duration = test_type_conf.duration_type.is_time_duration
-        return self.module.CommonOptions.construct(
+        return dict(
             duration_type=duration_type,
             duration=test_type_conf.duration
             if is_time_duration
             else test_type_conf.duration_frames,
-            duration_unit=test_type_conf.duration_time_unit
+            duration_unit=test_type_conf.duration_time_unit.name.lower()
             if is_time_duration
-            else self.module.DurationUnit[
-                test_type_conf.duration_frame_unit.name.lower()
-            ],
-            # duration_frames=test_type_conf.duration_frames,
-            # duration_frame_unit=test_type_conf.duration_frame_unit.core,
+            else test_type_conf.duration_frame_unit.name.lower(),
             iterations=test_type_conf.iterations,
         )
 
     def __gen_rate_iteration_options(
         self, rate_iteration_options: "LegacyRateIterationOptions"
-    ):
-        return self.module.RateIterationOptions.construct(
-            search_type=self.module.SearchType[
-                rate_iteration_options.search_type.name.lower()
-            ],
-            result_scope=self.module.RateResultScopeType[
-                rate_iteration_options.result_scope.name.lower()
-            ],
+    ) -> Dict:
+        return dict(
+            search_type=rate_iteration_options.search_type.name.lower(),
+            result_scope=rate_iteration_options.result_scope.name.lower(),
             initial_value_pct=rate_iteration_options.initial_value,
             minimum_value_pct=rate_iteration_options.minimum_value,
             maximum_value_pct=rate_iteration_options.maximum_value,
             value_resolution_pct=rate_iteration_options.value_resolution,
         )
 
-    def __gen_throughput(self, throughput: "LegacyThroughput"):
+    def __gen_throughput(self, throughput: "LegacyThroughput") -> Dict:
         rate_iteration_options = throughput.rate_iteration_options
-        return self.module.ThroughputTest.construct(
-            test_type=self.module.TestType[throughput.test_type.name.lower()],
+        return dict(
+            test_type=throughput.test_type.name.lower(),
             enabled=throughput.enabled,
             common_options=self.__gen_common_option(throughput),
             rate_iteration_options=self.__gen_rate_iteration_options(
@@ -193,50 +169,50 @@ class Converter2544:
             in throughput.report_property_options,
         )
 
-    def __gen_latency(self, latency: "LegacyLatency"):
-        return self.module.LatencyTest.construct(
-            test_type=self.module.TestType[latency.test_type.name.lower()],
+    def __gen_latency(self, latency: "LegacyLatency") -> Dict:
+        return dict(
+            test_type=latency.test_type.name.lower(),
             enabled=latency.enabled,
             common_options=self.__gen_common_option(latency),
             rate_sweep_options=self.__gen_rate_sweep_option(latency.rate_sweep_options),
-            latency_mode=latency.latency_mode,
+            latency_mode=latency.latency_mode.lower(),
             use_relative_to_throughput=latency.rate_relative_tput_max_rate,
         )
 
-    def __gen_loss(self, loss: "LegacyLoss"):
-        return self.module.FrameLossRateTest.construct(
-            test_type=self.module.TestType[loss.test_type.name.lower()],
+    def __gen_loss(self, loss: "LegacyLoss") -> Dict:
+        return dict(
+            test_type=loss.test_type.name.lower(),
             enabled=loss.enabled,
             common_options=self.__gen_common_option(loss),
             rate_sweep_options=self.__gen_rate_sweep_option(loss.rate_sweep_options),
             use_pass_fail_criteria=loss.use_pass_fail_criteria,
             acceptable_loss_pct=loss.acceptable_loss,
-            acceptable_loss_type=loss.acceptable_loss_type,
+            acceptable_loss_type=loss.acceptable_loss_type.lower(),
             use_gap_monitor=loss.use_gap_monitor,
             gap_monitor_start_microsec=loss.gap_monitor_start,
             gap_monitor_stop_frames=loss.gap_monitor_stop,
         )
 
-    def __gen_back_to_back(self, back_to_back: "LegacyBack2Back"):
-        return self.module.BackToBackTest.construct(
-            test_type=self.module.TestType[back_to_back.test_type.name.lower()],
+    def __gen_back_to_back(self, back_to_back: "LegacyBack2Back") -> Dict:
+        return dict(
+            test_type=back_to_back.test_type.name.lower(),
             enabled=back_to_back.enabled,
             common_options=self.__gen_common_option(back_to_back),
             rate_sweep_options=self.__gen_rate_sweep_option(
-                back_to_back.rate_sweep_options, Decimal(back_to_back.burst_resolution)
+                back_to_back.rate_sweep_options, (back_to_back.burst_resolution)
             ),
         )
 
-    def __gen_test_type_config(self):
+    def __gen_test_type_config(self) -> Dict:
         test_type_option_map = self.data.test_options.test_type_option_map
-        return self.module.TestTypesConfiguration.construct(
+        return dict(
             throughput_test=self.__gen_throughput(test_type_option_map.throughput),
             latency_test=self.__gen_latency(test_type_option_map.latency),
             frame_loss_rate_test=self.__gen_loss(test_type_option_map.loss),
             back_to_back_test=self.__gen_back_to_back(test_type_option_map.back2_back),
         )
 
-    def __gen_port_identity(self) -> Dict[str, "PortIdentity"]:
+    def __gen_port_identity(self) -> List:
         chassis_id_map = {}
         port_identity = {}
 
@@ -245,25 +221,26 @@ class Converter2544:
                 f"{chassis_info.host_name}:{chassis_info.port_number}".encode("utf-8")
             ).hexdigest()
             chassis_id_map[chassis_info.chassis_id] = chassis_id
-        count = 0
         chassis_id_list = list(chassis_id_map.values())
-        for p_info in self.data.port_handler.entity_list:
+        for count, p_info in enumerate(self.data.port_handler.entity_list):
             port = p_info.port_ref
             port.chassis_id = chassis_id_map[port.chassis_id]
-            identity = PortIdentity(
+            identity = dict(
                 tester_id=port.chassis_id,
                 tester_index=chassis_id_list.index(port.chassis_id),
                 module_index=port.module_index,
                 port_index=port.port_index,
             )
 
-            self.id_map[p_info.item_id] = (f"c-{identity.name}", f"p{count}")
+            self.id_map[p_info.item_id] = (
+                f"c-P-{identity['tester_index']}-{identity['module_index']}-{identity['port_index']}",
+                f"p{count}",
+            )
             port_identity[f"p{count}"] = identity
-            count += 1
         return port_identity
 
-    def __gen_ipv4_addr(self, entity: "LegacyPortEntity"):
-        return self.module.IPV4AddressProperties.construct(
+    def __gen_ipv4_addr(self, entity: "LegacyPortEntity") -> Dict:
+        return dict(
             address=entity.ip_v4_address,
             routing_prefix=entity.ip_v4_routing_prefix,
             gateway=entity.ip_v4_gateway if entity.ip_v4_gateway else "0.0.0.0",
@@ -276,8 +253,8 @@ class Converter2544:
             else "0.0.0.0",
         )
 
-    def __gen_ipv6_addr(self, entity: "LegacyPortEntity"):
-        return self.module.IPV6AddressProperties.construct(
+    def __gen_ipv6_addr(self, entity: "LegacyPortEntity") -> Dict:
+        return dict(
             address=entity.ip_v6_address,
             routing_prefix=entity.ip_v6_routing_prefix,
             gateway=entity.ip_v6_gateway if entity.ip_v6_gateway else "::",
@@ -294,15 +271,13 @@ class Converter2544:
         profile_id = self.data.stream_profile_handler.profile_assignment_map.get(
             f"guid_{entity.item_id}"
         )
-        logger.debug(list(self.module.PortRateCapProfile))
-        logger.debug(entity.port_rate_cap_profile.name)
-        return self.module.PortConfiguration.construct(
+        return dict(
             port_slot=self.id_map[entity.item_id][1],
             peer_config_slot=self.id_map[entity.pair_peer_id][0]
             if entity.pair_peer_id and entity.pair_peer_id in self.id_map
             else "",
-            port_group=entity.port_group,
-            port_speed_mode=entity.port_speed,
+            port_group=entity.port_group.lower(),
+            port_speed_mode=entity.port_speed.lower(),
             ipv4_properties=self.__gen_ipv4_addr(entity),
             ipv6_properties=self.__gen_ipv6_addr(entity),
             ip_gateway_mac_address=entity.ip_gateway_mac_address,
@@ -313,19 +288,15 @@ class Converter2544:
             speed_reduction_ppm=entity.adjust_ppm,
             pause_mode_enabled=entity.pause_mode_on,
             latency_offset_ms=entity.latency_offset,
-            fec_mode=self.module.FECModeStr[entity.fec_mode.name.lower()],
+            fec_mode=entity.fec_mode.name.lower(),
             port_rate_cap_enabled=bool(entity.enable_port_rate_cap),
             port_rate_cap_value=entity.port_rate_cap_value,
-            port_rate_cap_profile=self.module.PortRateCapProfile[
-                entity.port_rate_cap_profile.name.lower()
-            ],
-            port_rate_cap_unit=self.module.PortRateCapUnit[
-                entity.port_rate_cap_unit.name.lower()
-            ],
+            port_rate_cap_profile=entity.port_rate_cap_profile.name.lower(),
+            port_rate_cap_unit=entity.port_rate_cap_unit.name.lower().lstrip("field_"),
             auto_neg_enabled=bool(entity.auto_neg_enabled),
             anlt_enabled=bool(entity.anlt_enabled),
-            mdi_mdix_mode=entity.mdi_mdix_mode,
-            broadr_reach_mode=entity.brr_mode,
+            mdi_mdix_mode=entity.mdi_mdix_mode.lower(),
+            broadr_reach_mode=entity.brr_mode.lower(),
             profile_id=profile_id,
         )
 
@@ -335,15 +306,15 @@ class Converter2544:
             port_conf[self.id_map[entity.item_id][0]] = self.__gen_port_conf(entity)
         return port_conf
 
-    def gen(self) -> "TestParameters":
+    def gen(self) -> Dict:
         port_identities = self.__gen_port_identity()
         test_conf = self.__gen_test_config()
-        config = self.module.PluginModel2544.construct(
-            protocol_segments=convert_protocol_segments(self.data.stream_profile_handler, self.module),
+        config = dict(
+            protocol_segments=convert_protocol_segments(
+                self.data.stream_profile_handler
+            ),
             test_configuration=test_conf,
             test_types_configuration=self.__gen_test_type_config(),
             ports_configuration=self.__generate_port_config(),
         )
-        return TestParameters(
-            username="hello", config=config, port_identities=port_identities
-        )
+        return dict(username="hello", config=config, port_identities=port_identities)

--- a/xoa_converter/converters/rfc2544/enums.py
+++ b/xoa_converter/converters/rfc2544/enums.py
@@ -14,7 +14,6 @@ class LegacyDurationType(Enum):
     TIME = "seconds"
     FRAMES = "frames"
 
-
     @property
     def is_time_duration(self):
         return self == LegacyDurationType.TIME
@@ -30,6 +29,11 @@ class LegacySearchType(Enum):
     BINARY_SEARCH = "binarysearch"
     FAST_BINARY_SEARCH = "fastbinarysearc"
 
+
+class LegacyDurationTimeUnit(Enum):
+    SECONDS = "Seconds"
+    MINUTES = "Minutes"
+    HOURS = "Hours"
 
 
 class LegacyDurationFrameUnit(Enum):

--- a/xoa_converter/converters/rfc2544/model.py
+++ b/xoa_converter/converters/rfc2544/model.py
@@ -1,4 +1,3 @@
-
 from typing import Dict, List
 from pydantic import (
     BaseModel,
@@ -115,6 +114,7 @@ class LegacyHeaderSegments(BaseModel):
         else:
             return v
 
+
 class LegacyPayloadDefinition(BaseModel):
     payload_type: str = Field(alias="PayloadType")
     payload_pattern: str = Field(alias="PayloadPattern")
@@ -202,7 +202,7 @@ class LegacyThroughput(BaseModel):
     enabled: bool = Field(alias="Enabled")
     duration_type: enums.LegacyDurationType = Field(alias="DurationType")
     duration: float = Field(alias="Duration")
-    duration_time_unit: str = Field(alias="DurationTimeUnit")
+    duration_time_unit: enums.LegacyDurationTimeUnit = Field(alias="DurationTimeUnit")
     duration_frames: int = Field(alias="DurationFrames")
     duration_frame_unit: enums.LegacyDurationFrameUnit = Field(
         alias="DurationFrameUnit"
@@ -228,7 +228,7 @@ class LegacyLatency(BaseModel):
     enabled: bool = Field(alias="Enabled")
     duration_type: enums.LegacyDurationType = Field(alias="DurationType")
     duration: float = Field(alias="Duration")
-    duration_time_unit: str = Field(alias="DurationTimeUnit")
+    duration_time_unit: enums.LegacyDurationTimeUnit = Field(alias="DurationTimeUnit")
     duration_frames: int = Field(alias="DurationFrames")
     duration_frame_unit: enums.LegacyDurationFrameUnit = Field(
         alias="DurationFrameUnit"
@@ -252,7 +252,7 @@ class LegacyLoss(BaseModel):
     enabled: bool = Field(alias="Enabled")
     duration_type: enums.LegacyDurationType = Field(alias="DurationType")
     duration: float = Field(alias="Duration")
-    duration_time_unit: str = Field(alias="DurationTimeUnit")
+    duration_time_unit: enums.LegacyDurationTimeUnit = Field(alias="DurationTimeUnit")
     duration_frames: int = Field(alias="DurationFrames")
     duration_frame_unit: enums.LegacyDurationFrameUnit = Field(
         alias="DurationFrameUnit"
@@ -272,7 +272,7 @@ class LegacyBack2Back(BaseModel):
     enabled: bool = Field(alias="Enabled")
     duration_type: enums.LegacyDurationType = Field(alias="DurationType")
     duration: float = Field(alias="Duration")
-    duration_time_unit: str = Field(alias="DurationTimeUnit")
+    duration_time_unit: enums.LegacyDurationTimeUnit = Field(alias="DurationTimeUnit")
     duration_frames: int = Field(alias="DurationFrames")
     duration_frame_unit: enums.LegacyDurationFrameUnit = Field(
         alias="DurationFrameUnit"

--- a/xoa_converter/converters/rfc2889/model.py
+++ b/xoa_converter/converters/rfc2889/model.py
@@ -270,7 +270,6 @@ class PortRef(BaseModel):
     port_index: int = Field(alias="PortIndex")
 
 
-
 class LegacyPortEntity(BaseModel):
     port_ref: PortRef = Field(alias="PortRef")
     port_group: PortGroup = Field(alias="PortGroup")

--- a/xoa_converter/entry.py
+++ b/xoa_converter/entry.py
@@ -1,6 +1,6 @@
+import json
 from .converters import fabric
 from . import types
-from . import _generator
 
 
 def converter(test_suite_type: types.TestSuiteType, source_config: types.JsonStr, target_schema: types.JsonStr) -> str:
@@ -16,9 +16,5 @@ def converter(test_suite_type: types.TestSuiteType, source_config: types.JsonStr
     :rtype: str
     """
     converter_class = fabric.get_converter(test_suite_type)
-    target_module = _generator.gen_target_module(target_schema)
-    _model = converter_class(
-        source_config=source_config, 
-        target_module=target_module
-    ).gen()
-    return _model.json(indent=2)
+    _model = converter_class(source_config=source_config).gen()
+    return json.dumps(_model, indent=2)

--- a/xoa_converter/entry.py
+++ b/xoa_converter/entry.py
@@ -1,9 +1,14 @@
 import json
 from .converters import fabric
 from . import types
+from decimal import Decimal
 
 
-def converter(test_suite_type: types.TestSuiteType, source_config: types.JsonStr, target_schema: types.JsonStr) -> str:
+def converter(
+    test_suite_type: types.TestSuiteType,
+    source_config: types.JsonStr,
+    target_schema: types.JsonStr,
+) -> str:
     """Convert an Valkyrie test suite application's config file into XOA's test suite config.
 
     :param test_suite_type: Registered test suite type.


### PR DESCRIPTION
### Deps setup
```
    driver1.0.12: xoa-driver==1.0.12
    core1.0.7: xoa-core==1.0.7
    coregitmain: git+https://github.com/xenanetworks/open-automation-core.git@main
    convertergitfix: git+https://github.com/xenanetworks/open-automation-config-converter.git@fix-issue14-update-ref
```

### Test was passed on following deps combination
```
  driver1.0.12-core1.0.7-convertergitfix: OK (86.58=setup[21.88]+cmd[64.70] seconds)
  driver1.0.12-coregitmain-convertergitfix: OK (92.41=setup[27.70]+cmd[64.70] seconds)
  congratulations :) (179.02 seconds)
`````

### Test content
```
suite_for_testing = [
    TestSuiteInfo(suite_type=TestSuiteType.RFC2544, valkyrie_config_path=VALKYRIE_CONFIG_FILE_2544),
    TestSuiteInfo(suite_type=TestSuiteType.RFC2889, valkyrie_config_path=VALKYRIE_CONFIG_FILE_2889),
]


@pytest.mark.asyncio
async def test_plugins(tester_197):
    xoa_controller = await controller.MainController()
    xoa_controller.register_lib( str(PATH_PLUGINS) )
    await xoa_controller.add_tester(tester_197)

    for test_suite in suite_for_testing:
        info = xoa_controller.get_test_suite_info(test_suite.suite_type.value)
        assert info
        with open(test_suite.valkyrie_config_path, "r") as f:
            new_data = converter(test_suite.suite_type, f.read(), info["schema"])
            new_config = json.loads(new_data)
            execution_id = xoa_controller.start_test_suite(test_suite.suite_type.value, new_config)
            async for msg in xoa_controller.listen_changes(execution_id, _filter={types.EMsgType.STATISTICS}):
                assert msg
```